### PR TITLE
[MCP] Add resource annotations to engines_index

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -19,7 +19,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import re
-from mcp.types import ToolAnnotations
+from mcp.types import Annotations, ToolAnnotations
 
 load_dotenv()
 
@@ -42,6 +42,10 @@ def _get_engine_files() -> list[Path]:
     name="serpapi-engines-index",
     description="Index of available SerpApi engines and their resource URIs.",
     mime_type="application/json",
+    annotations=Annotations(
+        audience=["assistant"],
+        priority=0.3,
+    ),
 )
 def engines_index() -> ResourceResult:
     engine_files = _get_engine_files()


### PR DESCRIPTION
# [MCP] Add resource annotations to engines_index

## What

Adds `Resource.annotations` to the `engines_index` resource in
`src/server.py`. The resource is currently registered without any hints,
which means MCP clients can't distinguish the discovery index from
user-facing or high-priority content. After this change, clients can
classify it correctly and deprioritize it in context-window budgeting.

```python
@mcp.resource(
    "serpapi://engines",
    name="serpapi-engines-index",
    description="Index of available SerpApi engines and their resource URIs.",
    mime_type="application/json",
    annotations=Annotations(
        # discovery index for the LLM agent — not user-facing content
        audience=["assistant"],
        # low priority: this is a discovery index, only needed when picking an engine
        priority=0.3,
    ),
)
def engines_index() -> ResourceResult:
    ...
```

## Why

Follow-up to #43 — @adarshdigievo's review noted that the
`engines_index` resource lacks a `ResourceAnnotations` block.

The MCP 2025-11-25 spec distinguishes between `ToolAnnotations` (safety hints) and
`ResourceAnnotations` (audience + priority). Implementing these allows
MCP clients to perform smarter context-window budgeting and UI rendering:

- **`audience=["assistant"]`**: We explicitly flag this as agent-only
  routing metadata. This tells the Host client to keep the index out
  of user-facing UI elements (like resource pickers or attachments) to
  maintain a clean interface.
- **`priority=0.3`**: The MCP spec utilizes a `0.0` to `1.0` scale for
  context eviction algorithms, where `0.5` is the implicit baseline.
  By mathematically degrading the index to `0.3`, we instruct the
  Host's context-manager that this is low-priority discovery metadata.
  In heavy, multi-turn chat sessions, the Host can safely drop this
  index from the VRAM context before it ever touches critical search
  results or system prompts.

## Compatibility

- **Backward compatible**: `Resource.annotations` is a hint structure in
  the MCP spec. Adding it doesn't change the resource's content, URI, or
  MIME type. Existing clients that ignore the field continue to work
  unchanged.
- **No new dependencies**: `mcp.types.Annotations` is exported by the
  `mcp` package that this project already depends on (`fastmcp>=3.2.0`
  re-exports the same namespace).
- **CI**: passes `uv format --check` (ruff-formatted). No type-hint
  changes needed.

Note on the spec: per the MCP 2025-11-25 spec
(`https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations-idempotenthint`),
`ResourceAnnotations` only exposes `audience` and `priority`. The
safety hints from `ToolAnnotations` (`readOnlyHint`, `destructiveHint`,
`idempotentHint`, `openWorldHint`) are intentionally **not** set — they
are tool-only and don't apply to resources.

## Validation

- **Format**: `uv format --check` → `3 files already formatted` (CI
  green).
- **Import**: `uv run python -c "from src.server import mcp"` succeeds
  without error.
- **Resource registration**:
  ```
  await mcp.get_resource("serpapi://engines")
  → name="serpapi-engines-index"
  → mime_type="application/json"
  → annotations={'audience': ['assistant'], 'priority': 0.3}
  ```
- **Functional**: `await r.read()` returns the full index of 107
  engines with the same JSON shape as before the change (verified
  locally; `count`, `engines`, `resources`, `schema` all preserved).

## Scope boundary (what this PR does NOT include)

- No change to the resource's content, URI, name, or MIME type.
- No change to the per-engine resources (`serpapi://engines/<engine>`),
  which are registered dynamically from the `engines/*.json` files via
  `_engine_resource_factory`. They have the same
  discovery-metadata-shape profile; could be a follow-up if maintainers
  want symmetry.
- No change to the `search` tool annotations (those are already in #43).
- No deprecation of any existing field.
- No new tests (issue #34 "code mode" + #36 pytest are tracked
  separately).
