### PR TITLE
[MCP] Scale up ECS replicas and add uvicorn workers to fix gateway timeouts

### DIFF
--- a/copilot/mcp-server-api/manifest.yml
+++ b/copilot/mcp-server-api/manifest.yml
@@ -14,8 +14,8 @@ memory: 4096
 platform: linux/x86_64
 count:
   range:
-    min: 3
-    max: 6
+    min: 5
+    max: 15
   cpu_percentage: 70
 exec: true
 network:

--- a/src/server.py
+++ b/src/server.py
@@ -137,7 +137,8 @@ def main():
     host = os.getenv("MCP_HOST", "0.0.0.0")
     port = int(os.getenv("MCP_PORT", "8000"))
 
-    uvicorn.run(starlette_app, host=host, port=port, ws="none")
+    workers = int(os.getenv("WEB_CONCURRENCY", "4"))
+    uvicorn.run(starlette_app, host=host, port=port, ws="none", workers=workers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Increase ECS task range from 3-6 to 5-15 and run 4 uvicorn workers per container.