### PR TITLE
Attempt #2: Scale up ECS replicas and add uvicorn workers to fix gateway timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN python /app/build-engines.py
 
 EXPOSE 8000
 
-CMD ["python", "src/server.py"]
+CMD ["sh", "-c", "exec uvicorn src.server:starlette_app --host ${MCP_HOST:-0.0.0.0} --port ${MCP_PORT:-8000} --workers ${WEB_CONCURRENCY:-4} --ws none"]

--- a/copilot/mcp-server-api/manifest.yml
+++ b/copilot/mcp-server-api/manifest.yml
@@ -14,8 +14,8 @@ memory: 4096
 platform: linux/x86_64
 count:
   range:
-    min: 3
-    max: 6
+    min: 5
+    max: 15
   cpu_percentage: 70
 exec: true
 network:

--- a/src/server.py
+++ b/src/server.py
@@ -137,7 +137,8 @@ def main():
     host = os.getenv("MCP_HOST", "0.0.0.0")
     port = int(os.getenv("MCP_PORT", "8000"))
 
-    uvicorn.run(starlette_app, host=host, port=port, ws="none")
+    workers = int(os.getenv("WEB_CONCURRENCY", "4"))
+    uvicorn.run(starlette_app, host=host, port=port, ws="none", workers=workers)
 
 
 if __name__ == "__main__":

--- a/src/server.py
+++ b/src/server.py
@@ -116,30 +116,26 @@ async def healthcheck_handler(request):
     )
 
 
-def main():
-    middleware = [
-        Middleware(RequestMetricsMiddleware),
-        Middleware(ApiKeyMiddleware),
-        Middleware(
-            CORSMiddleware,
-            allow_origins=["*"],
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        ),
-    ]
-    starlette_app = mcp.http_app(
-        middleware=middleware, stateless_http=True, json_response=True
-    )
+middleware = [
+    Middleware(RequestMetricsMiddleware),
+    Middleware(ApiKeyMiddleware),
+    Middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    ),
+]
+starlette_app = mcp.http_app(
+    middleware=middleware, stateless_http=True, json_response=True
+)
 
-    starlette_app.add_route("/healthcheck", healthcheck_handler, methods=["GET"])
+starlette_app.add_route("/healthcheck", healthcheck_handler, methods=["GET"])
 
+if __name__ == "__main__":
     host = os.getenv("MCP_HOST", "0.0.0.0")
     port = int(os.getenv("MCP_PORT", "8000"))
 
     workers = int(os.getenv("WEB_CONCURRENCY", "4"))
     uvicorn.run(starlette_app, host=host, port=port, ws="none", workers=workers)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
- Fixes 'uvicorn.run()' unsupported worker issue.
- An alternative implementation to achieve the goals of https://github.com/serpapi/serpapi-mcp/pull/57
- Multiple workers are confirmed to be running when the `Dockerfile` is built and run.