### PR TITLE
[MCP] Upgrade Copilot Lambda runtimes to Node.js 24

### DIFF
--- a/copilot/mcp-server-api/overrides/cfn.patches.yml
+++ b/copilot/mcp-server-api/overrides/cfn.patches.yml
@@ -1,0 +1,11 @@
+- op: replace
+  path: /Resources/DynamicDesiredCountFunction/Properties/Runtime
+  value: nodejs24.x
+
+- op: replace
+  path: /Resources/EnvControllerFunction/Properties/Runtime
+  value: nodejs24.x
+
+- op: replace
+  path: /Resources/RulePriorityFunction/Properties/Runtime
+  value: nodejs24.x


### PR DESCRIPTION
## Summary
- add a persistent Copilot YAML patch override for all three service-managed Lambda functions
- move the generated Lambda runtimes from unsupported Node.js 20 to Node.js 24
- keep CloudFormation as the source of truth instead of introducing console drift

## Test plan
- [x] Run `copilot svc package --name mcp-server-api --env prod`
- [x] Verify the rendered template sets `DynamicDesiredCountFunction`, `EnvControllerFunction`, and `RulePriorityFunction` to `nodejs24.x`
- [x] Check the override file for linter errors